### PR TITLE
Handle objects which do not have a symbol in isFunctionLike

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -98,7 +98,9 @@ export function isUnionBoolean(types: ts.Type[]) {
  * This is an approximation to determine if an "object" represents a function or a method
  */
 export function isFunctionLike(object: ts.ObjectType) {
-    const check = object.symbol.flags & ts.SymbolFlags.Function || object.symbol.flags & ts.SymbolFlags.Method
+    const check =
+        object.symbol != null &&
+        (object.symbol.flags & ts.SymbolFlags.Function || object.symbol.flags & ts.SymbolFlags.Method)
     return Boolean(check)
 }
 


### PR DESCRIPTION
The type for ts.ObjectType.symbol is optional but isFunctionLike assumes
that it is always present. I assume that all functions have that
property populated as I cannot find evidence that would say otherwise.