### PR TITLE
Transpile falsey type literals correctly

### DIFF
--- a/src/transpiler.ts
+++ b/src/transpiler.ts
@@ -182,7 +182,7 @@ function resolveTypeNode<T>(startNode: ts.Node, checker: ts.TypeChecker, module:
         }
         if (Types.isLiteral(type)) {
             // When a literal type does not have a value it's a true or false literal
-            if (!type.value) {
+            if (type.value == null) {
                 // True or false literals are not typed in the library but they have an intrinsic name
                 return module.buildLiteral((type as any).intrinsicName === 'true')
             }


### PR DESCRIPTION
Instead of assuming that all literals that are falsey are a boolean,
actually check that the value is undefined or null.