### PR TITLE
Do not replace over whole type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Issue where references were not using `Joi.lazy`
+
 ## [0.3.1] - 2020/06/08
 
 ## [0.3.0] - 2020/01/21

--- a/src/modules/joi.ts
+++ b/src/modules/joi.ts
@@ -110,7 +110,13 @@ export class JoiModule implements Transpiler.Module<JoiSchema> {
         // If something is lazy we remove the lazy part to make sure that we are dealing with objects only and then
         // We concatenate them
         const concats = resolvedTypes
-            .map(lazyType => lazyType.replace('Joi.lazy(() => ', '('))
+            .map(lazyType => {
+                if (lazyType.startsWith('Joi.lazy(() => ')) {
+                    return lazyType.replace('Joi.lazy(() => ', '(')
+                }
+
+                return lazyType
+            })
             .map(type => `.concat(${type})`)
 
         // The new object, result of all the concatenated parts


### PR DESCRIPTION
Do not dive deeply into type and replace arbitrary references.
Only replace top level one.