### PR TITLE
Only allow Joi null/undefined when passed a null/undefined value

### DIFF
--- a/src/modules/joi.ts
+++ b/src/modules/joi.ts
@@ -66,11 +66,11 @@ export class JoiModule implements Transpiler.Module<JoiSchema> {
             case 'any':
                 return this.buildAny()
             case 'void':
-                return 'Joi.allow(undefined)'
+                return 'Joi.valid(undefined)'
             case 'null':
-                return `Joi.allow(null)`
+                return `Joi.valid(null)`
             case 'undefined':
-                return 'Joi.allow(undefined)'
+                return 'Joi.valid(undefined)'
             case 'never':
                 return `Joi.forbidden()`
             case 'string':
@@ -132,7 +132,7 @@ export class JoiModule implements Transpiler.Module<JoiSchema> {
     public buildObject(properties: ResolvedProperty[], type: Transpiler.TypeIdentification): JoiSchema {
         const propertiesSchema = properties
             // Handle the case when someone defined something like `{ property: undefined }` by ignoring that completely
-            .filter(({ resolvedType }) => resolvedType !== 'Joi.allow(undefined)')
+            .filter(({ resolvedType }) => resolvedType !== 'Joi.valid(undefined)')
             .map(({ maybeUndefined, isOptional, name, resolvedType }) => {
                 const nameString = name.includes('-') ? `'${name}'` : name
 

--- a/test/basicTypes/basicTypes.expected.ts
+++ b/test/basicTypes/basicTypes.expected.ts
@@ -20,9 +20,9 @@ export const json = [
 
 export const joi = [
     'const resolvedType = Joi.any()',
-    'const resolvedType = Joi.allow(undefined)',
-    'const resolvedType = Joi.allow(null)',
-    'const resolvedType = Joi.allow(undefined)',
+    'const resolvedType = Joi.valid(undefined)',
+    'const resolvedType = Joi.valid(null)',
+    'const resolvedType = Joi.valid(undefined)',
     'const resolvedType = Joi.forbidden()',
     'const resolvedType = Joi.string()',
     'const resolvedType = Joi.number()',

--- a/test/nullables/nullables.expected.ts
+++ b/test/nullables/nullables.expected.ts
@@ -18,8 +18,8 @@ export const json = [
 ]
 
 export const joi = [
-    'const resolvedType = Joi.alternatives([Joi.allow(null),Joi.any()])',
-    'const resolvedType = Joi.alternatives([Joi.allow(null),Joi.string()])',
+    'const resolvedType = Joi.alternatives([Joi.valid(null),Joi.any()])',
+    'const resolvedType = Joi.alternatives([Joi.valid(null),Joi.string()])',
     'const resolvedType = Joi.string()',
-    'const resolvedType = Joi.object({ continent: Joi.alternatives([Joi.allow(null),Joi.string()]),country: Joi.alternatives([Joi.allow(null),Joi.string()]),state: Joi.string().optional(),city: Joi.alternatives([Joi.allow(null),Joi.string()]),street: Joi.string() })',
+    'const resolvedType = Joi.object({ continent: Joi.alternatives([Joi.valid(null),Joi.string()]),country: Joi.alternatives([Joi.valid(null),Joi.string()]),state: Joi.string().optional(),city: Joi.alternatives([Joi.valid(null),Joi.string()]),street: Joi.string() })',
 ]


### PR DESCRIPTION
Previously it was generating the Joi schema `Joi.allow(null)` for null
values, this is an alias for `Joi.any.allow(null)`. Allow is for
specifying values that are accepted in addition to the already defined
filter, and since the default filter is `any` it means that these
filters will accept any value.

`Joi.valid` seems like what it should be instead as `valid` restricts
the schema to only the values specified.