### PR TITLE
allow single value for array

### DIFF
--- a/src/modules/joi.ts
+++ b/src/modules/joi.ts
@@ -89,7 +89,7 @@ export class JoiModule implements Transpiler.Module<JoiSchema> {
     }
 
     public buildArray(resolvedType: JoiSchema): JoiSchema {
-        return `Joi.array().items(${resolvedType})`
+        return `Joi.array().items(${resolvedType}).single()`;
     }
 
     public buildTuple(resolvedTypes: JoiSchema[]): JoiSchema {

--- a/test/basicTypes/basicTypes.expected.ts
+++ b/test/basicTypes/basicTypes.expected.ts
@@ -29,9 +29,9 @@ export const joi = [
     'const resolvedType = Joi.boolean()',
     'const resolvedType = Joi.equal(true)',
     'const resolvedType = Joi.equal(false)',
-    'const resolvedType = Joi.array().items(Joi.string())',
-    'const resolvedType = Joi.array().items(Joi.number())',
-    'const resolvedType = Joi.array().items(Joi.boolean())',
+    'const resolvedType = Joi.array().items(Joi.string()).single()',
+    'const resolvedType = Joi.array().items(Joi.number()).single()',
+    'const resolvedType = Joi.array().items(Joi.boolean()).single()',
     'const resolvedType = Joi.array().ordered([Joi.string(),Joi.number(),Joi.boolean()])',
     'const resolvedType = Joi.alternatives([Joi.equal("Red"),Joi.equal("Green"),Joi.equal("Blue")])',
 ]

--- a/test/classes/classes.expected.ts
+++ b/test/classes/classes.expected.ts
@@ -112,8 +112,8 @@ export const joi = [
     'const resolvedType = Joi.object({ name: Joi.string(),speed: Joi.number() })',
     'const resolvedType = Joi.object({ _barkCount: Joi.number(),name: Joi.string(),speed: Joi.number(),isDog: Joi.boolean() })',
     'const resolvedType = Joi.object({ name: Joi.string(),speed: Joi.number() })',
-    'const resolvedType = Joi.object({ authors: Joi.array().items(Joi.string()) })',
-    'const resolvedType = Joi.object({ colors: Joi.array().items(Joi.string()),authors: Joi.array().items(Joi.string()) })',
+    'const resolvedType = Joi.object({ authors: Joi.array().items(Joi.string()).single() })',
+    'const resolvedType = Joi.object({ colors: Joi.array().items(Joi.string()).single(),authors: Joi.array().items(Joi.string()).single() })',
     'const resolvedType = Joi.object({ x: Joi.number(),y: Joi.number() })',
     'const resolvedType = Joi.object({ z: Joi.number(),x: Joi.number(),y: Joi.number() })',
 ]

--- a/test/recursion/recursion.expected.ts
+++ b/test/recursion/recursion.expected.ts
@@ -52,6 +52,6 @@ export const json = [
 
 export const joi = [
     'const resolvedType = Joi.object({ name: Joi.string(),id: Joi.string() })',
-    'const Team = Joi.object({ users: Joi.array().items(Joi.object({ name: Joi.string(),id: Joi.string() })),parent: Joi.lazy(() => Team).optional() })\nconst resolvedType = Joi.lazy(() => Team)',
+    'const Team = Joi.object({ users: Joi.array().items(Joi.object({ name: Joi.string(),id: Joi.string() })).single(),parent: Joi.lazy(() => Team).optional() })\nconst resolvedType = Joi.lazy(() => Team)',
     'const OneLanguageTranslations = \nconst resolvedType = Joi.object().pattern(/.*/, Joi.alternatives([Joi.string(),Joi.lazy(() => OneLanguageTranslations)]))',
 ]


### PR DESCRIPTION
query encoded as `qs.stringify(query, { arrayFormat: 'repeat' })` would fail for single value like `?q=value`